### PR TITLE
Fixed path do data dir and class name

### DIFF
--- a/code/Unidecode.php
+++ b/code/Unidecode.php
@@ -108,4 +108,4 @@ class Unidecode {
 	}
 }
 
-Unicode::$containing_dir = dirname(__FILE__) ;
+Unidecode::$containing_dir = dirname(__FILE__) ;

--- a/code/Unidecode.php
+++ b/code/Unidecode.php
@@ -76,7 +76,7 @@ class Unidecode {
 
 			if ( !isset( self::$tr[$h] ) ) {
 				$fname = sprintf( 'x%02x.php', $h ) ;
-				include self::$containing_dir . "/data/$fname" ;
+				include self::$containing_dir . "/../data/$fname" ;
 			}
 
 			return Unidecode::$tr[$h][$l] ;
@@ -95,7 +95,7 @@ class Unidecode {
 
 			if ( !isset( self::$tr[$h] ) ) {
 				$fname = sprintf( 'x%02x.php', $h ) ;
-				include self::$containing_dir . "/data/$fname" ;
+				include self::$containing_dir . "/../data/$fname" ;
 			}
 
 			return Unidecode::$tr[$h][$l] ;


### PR DESCRIPTION
Hello,

I made the following changes:
- the $containing_dir property was initialized on a class called Unicode; it should be Unidecode
- the data dir sits on the same level as the code dir thus, the right path is ../data, instead of /data

Alexei
